### PR TITLE
Add Markdoc to the generators list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ This should be updated fairly regularly. As usual, **pull requests are encourage
 * [DocumentUp](http://documentup.com/) - Instantly beautify your Github repositories' `README.md`. (contributed by [@kylewest](https://twitter.com/kylewest))
 * [Sphinx](http://sphinx.pocoo.org/) - Comprehensive documentation tool using restructuredText with beautiful HTML and PDF output. (contributed by [@nikhilcutshort](https://twitter.com/nikhilcutshort))
 * [dr.js](https://github.com/DmitryBaranovskiy/dr.js) - Tiny JavaScript documentation generator from the author of RaphaëlJS.  (contributed by [@nikhilcutshort](https://twitter.com/nikhilcutshort))
+* [Markdoc](http://markdoc.org/) - Lightweight documentation/wiki generator in Python, released in the [public domain](http://unlicense.org/). (contributed by [Neelfyn](http://neelfyn.info/))


### PR DESCRIPTION
It would be great to include Markdoc too. It's a very nice small Python generator, you can use it with version control systems, it's public domain software... everything you could ever dream of, basically.
