### PR TITLE
Added MireDot

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ This should be updated fairly regularly. As usual, **pull requests are encourage
 * [docgenerator](https://github.com/Ralt/docgenerator/blob/master/README.md) - Organize your documentation in Markdown files. (contributed by [Florian Margaine](http://margaine.com))
 * [dexy](http://www.dexy.it/) - Extensible documentation/report generator supporting multiple programming languages and serveral input and output formats. (contributed by [troytop](http://github.com/troytop))
 * [Slate](https://github.com/tripit/slate) - Static API documentation creation tool from the team at Tripit.  
-* [MireDot] - REST API documentation generator for Java. Plugs into your build process and generates a searchable html page. (contributed by [bertvh](https://github.com/bertvh))
+* [MireDot](http://www.miredot.com) - REST API documentation generator for Java. Plugs into your build process and generates a searchable html page. (contributed by [bertvh](https://github.com/bertvh))


### PR DESCRIPTION
We're working on MireDot, a REST API documentation generator for Java (as an alternative to Swagger and Enunciate. I think if fits well in the list of the documentation generators.
