### PR TITLE
Adding Flatdoc to the Generating Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,5 @@ This should be updated fairly regularly. As usual, **pull requests are encourage
 * [ApiGen](http://apigen.org/) - Creates clean API documentation from PHP source code (contributed by [bryceadams](http://bryce.se/))
 * [docgenerator](https://github.com/Ralt/docgenerator/blob/master/README.md) - Organize your documentation in Markdown files. (contributed by [Florian Margaine](http://margaine.com))
 * [dexy](http://www.dexy.it/) - Extensible documentation/report generator supporting multiple programming languages and serveral input and output formats. (contributed by [troytop](http://github.com/troytop))
-* [Slate](https://github.com/tripit/slate) - Static API documentation creation tool from the team at Tripit.  
+* [Slate](https://github.com/tripit/slate) - Static API documentation creation tool from the team at Tripit.
+* [Flatdoc](http://ricostacruz.com/flatdoc/) - Create well designed open source documentation from Github repository readme files or simple Markdown files. (contributed by [@moore](http://twitter.com/moore)


### PR DESCRIPTION
I think that Flatdoc would make a great addition to the generating docs list - http://ricostacruz.com/flatdoc/.  It's a simple Javascript file that fetches Markdown files from your Github repo and generates easy to follow docs.
