### PR TITLE
Adding Barricade Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This should be updated fairly regularly. As usual, **pull requests are encourage
 * [Mailjet API guides](http://dev.mailjet.com/) - Great documentation with generated code samples using Slate from Tripit
 * [Atlassian GIT Tutorials](https://www.atlassian.com/git/) - Documentation and tutorials on Git. I like their layout. It is simple and foucssed on explaining the concepts with good diagrams, tutorials and glossary. (contributed by [@vaseehh](https://twitter.com/vaseehh))
 * [Digital Ocean API Docs](https://developers.digitalocean.com/documentation/v2/) - These docs are stellar. Examples are abundant and the organization makes each component of the API easy to reason about. (contributed by [@jasonaibrahim](https://github.com/jasonaibrahim))
+* [Barricade Docs](https://barricadeio.github.io/docs/) - An open-sourced docs website that emphasises nice typography and clear navigation. These docs were built as a [custom Hugo theme](https://github.com/flynnduism/docs) for the Barricade service. (contributed by [@flynnduism](https://twitter.com/flynnduism))
 
 ### Writing about Docs 
 


### PR DESCRIPTION
Adding [docs.barricade.io](https://docs.barricade.io/) - an [open source site](https://github.com/flynnduism/docs), built with the Foundation framework and the [Hugo](https://gohugo.io/) static site generator.

_Disclaimer: I designed and built this site_.

---   

I've spent some time looking for a way to create nice, flexible documentation sites.
**Thank you** for your work with Beautiful Docs, there are many great resources here. 

For a lot of smaller teams, I've found that beautiful/usable docs are often not a priority, and they will use a paid, SaaS knowledge base or help desk type tool to host their content. IMO most of these services tend to be expensive and hard to customize, so I wanted to build something simple and customizable with a static site generator. Hopefully it's worthy of inclusion!