### PR TITLE
Add DocRaptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This should be updated fairly regularly. As usual, **pull requests are encourage
 * [Mailjet API guides](http://dev.mailjet.com/) - Great documentation with generated code samples using Slate from Tripit
 * [Atlassian GIT Tutorials](https://www.atlassian.com/git/) - Documentation and tutorials on Git. I like their layout. It is simple and foucssed on explaining the concepts with good diagrams, tutorials and glossary. (contributed by [@vaseehh](https://twitter.com/vaseehh))
 * [Digital Ocean API Docs](https://developers.digitalocean.com/documentation/v2/) - These docs are stellar. Examples are abundant and the organization makes each component of the API easy to reason about. (contributed by [@jasonaibrahim](https://github.com/jasonaibrahim))
+* [DocRaptor](https://docraptor.com/documentation) Covers HTML-to-PDF API language wrappers, styling instructions and core API docs.
 
 ### Writing about Docs 
 


### PR DESCRIPTION
Note: DocRaptor is an HTML to PDF API, not a documentation generator, just to be clear :)