### PR TITLE
Add Supabase and Neon docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This should be updated fairly regularly. As usual, **pull requests are encourage
 * [Circles, Sines and Signals](https://jackschaedler.github.io/circles-sines-signals/) - A Compact Primer on Digital Signal Processing. (contributed by [@PharkMillups](https://github.com/PharkMillups))
 * [PostgreSQL](https://www.postgresql.org/docs/current/index.html) - One of the most reliable sets of documentation available. There is rarely a need to go outside the documentation. (contributed by [@dalryan](https://github.com/dalryan))
 * [Svelte](https://svelte.dev/docs/introduction) - Svelte shifts as much work as possible out of the browser and into your build step. No more manual optimisations — just faster, more efficient apps. (contributed by [@0Ared](https://github.com/0Ared/))
+* [Supabase](https://supabase.com/docs) - Clean, well-organized docs with a sleek design. Covers a wide range of topics from getting started to advanced features, with clear navigation and code examples. (contributed by [tyaga001](https://github.com/tyaga001/))
+* [Neon Postgres Database](https://neon.tech/docs/introduction) - Comprehensive and user-friendly documentation for Neon's serverless Postgres. Features a clear structure, good use of whitespace, and helpful diagrams to explain concepts. (contributed by [tyaga001](https://github.com/tyaga001/))
 
 ### Writing about Docs
 


### PR DESCRIPTION
Added entries for [Supabase](https://supabase.com) and [Neon](https://neon.tech) documentation. Both offer clean, well-structured docs